### PR TITLE
change deployment/livenessProbe/httpGet/path

### DIFF
--- a/charts/growi/templates/deployment.yaml
+++ b/charts/growi/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             protocol: TCP
           livenessProbe:
             httpGet:
-              path: /_api/v3/healthcheck
+              path: /_api/v3/healthcheck?connectToMiddlewares
               port: http
             initialDelaySeconds: 10
           readinessProbe:


### PR DESCRIPTION
Tested with:
helm version: 3.1.0
Kubernetes GKE v1.14.10-gke.17